### PR TITLE
Remove dead code in session tracker

### DIFF
--- a/src/hrbot/services/session_tracker.py
+++ b/src/hrbot/services/session_tracker.py
@@ -36,10 +36,6 @@ class SessionTracker:
         self._last_seen[user_id] = datetime.now(timezone.utc)
         return self._current[user_id]
 
-        # touch last-seen timestamp
-        self._last_seen[user_id] = datetime.now(timezone.utc)
-        return self._current[user_id]
-
     def end_session(self, user_id: str) -> None:
         """Explicitly close the session (called when feedback is submitted)."""
         self._current.pop(user_id, None)


### PR DESCRIPTION
## Summary
- remove unreachable lines in `session_tracker.get`

## Testing
- `poetry run pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_684f628d679083288eeed20a4adb0ea5