### PR TITLE
Fix RAG adapter import

### DIFF
--- a/src/hrbot/api/routers/admin.py
+++ b/src/hrbot/api/routers/admin.py
@@ -219,7 +219,7 @@ async def test_rag(query: dict):
     try:
         # Import here to avoid circular imports
         from hrbot.core.rag.engine import RAG
-        from hrbot.core.rag_adapter import LLMServiceAdapter
+        from hrbot.core.adapters.llm_gemini import LLMServiceAdapter
         from hrbot.services.gemini_service import GeminiService
 
         llm_adapter = LLMServiceAdapter(GeminiService())


### PR DESCRIPTION
## Summary
- correct the LLMServiceAdapter import in admin router

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f65b9889c8328a9e4da04d39fc2c5